### PR TITLE
Add functionality for delete discount button

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -23,6 +23,14 @@ class BulkDiscountsController < ApplicationController
     end
   end
 
+  def destroy
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = BulkDiscount.find(params[:id])
+    @bulk_discount.destroy
+    redirect_to "/merchant/#{@merchant.id}/bulk_discounts"
+    flash[:success] = "Discount Deleted Successfully"
+  end
+
 
   private
 

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -3,13 +3,15 @@
 
   <p><%= link_to "Create New Discount", "/merchant/#{@merchant.id}/bulk_discounts/new" %></p>
 
-  <ul class='ml-auto col-sm-4'>
-    <section id = "discount_list" >
+  <ul id = 'discount_list'>
+    <section id = "discount_indiv" >
       <p><% @merchant.bulk_discounts.each do |discount| %>
             <h3>
             <%= link_to "#{(discount.percentage_discount * 100).round}% Discount", "/merchant/#{@merchant.id}/bulk_discounts/#{discount.id}" %>
             </h3>
-            <ul>Quantity Threshold: <%= discount.quantity_threshold %></ul><br><br>
+            <p>Quantity Threshold: <%= discount.quantity_threshold %></p>
+            <%= button_to "Delete", "/merchant/#{@merchant.id}/bulk_discounts/#{discount.id}", method: :delete, data: { confirm: "Delete this Discount?" } %>
+            <br><br>
         <% end %>
       </p> 
     </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create], controller: "bulk_discounts"
+    resources :bulk_discounts, except: [:update], controller: "bulk_discounts"
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Bulk Discounts Index' do
     expect(page).to have_content("Hair Care's Bulk Discounts")
     expect(page).to_not have_content("Dandelion Plant's Bulk Discounts")
     
-    within "#discount_list" do 
+    within "#discount_indiv" do 
       expect(page).to have_content("15% Discount")
       expect(page).to have_content("Quantity Threshold: 15")
 
@@ -56,5 +56,26 @@ RSpec.describe 'Bulk Discounts Index' do
   it 'When I click this link, I am taken to a new page' do
     click_link("Create New Discount")
     expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts/new")
+  end
+
+  it 'next to each bulk discount, I see a link to delete it' do
+    within "#discount_indiv" do
+      expect(page).to have_button("Delete")
+    end
+  end
+
+  it 'I click delete link, am redirected to the bulk discounts index page, and no longer see that discount' do
+    first(:button, "Delete").click
+
+    expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts")
+    expect(page).to have_content("Discount Deleted Successfully")
+    expect(page).to_not have_content("15% Discount")
+    expect(page).to_not have_content("Quantity Threshold: 15")
+    expect(page).to have_content("20% Discount")
+    expect(page).to have_content("Quantity Threshold: 20")
+    expect(page).to have_content("25% Discount")
+    expect(page).to have_content("Quantity Threshold: 30")
+    expect(page).to have_content("30% Discount")
+    expect(page).to have_content("Quantity Threshold: 50")
   end
 end


### PR DESCRIPTION
3: Merchant Bulk Discount Delete

As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a link to delete it
When I click this link
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed