### PR TITLE
5 user story

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,0 +1,57 @@
+.navbar {
+  margin-bottom: 30px;
+}
+.navbar-text {
+  margin-top: 1px;
+  margin-bottom: 1px;
+  font-weight: bold;
+}
+.col-sm-5 {
+  background-color:lavender;
+  font-weight: bold;
+  text-align:center;
+  margin-right: 80px
+}
+.col-sm-4 {
+  text-align:left;
+  margin-right: 80px;
+  margin-left: 10px
+}
+.col-sm-6 {
+  background-color:lavenderblush;
+  font-weight: bold;
+  text-align:center;
+}
+.col-12 {
+  background-color:#EBEFF3;
+  font-weight: bold;
+  text-align:center;
+  margin-right: 80px;
+  margin-left: 10px
+}
+
+.table {
+  font-family: arial, sans-serif;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.td {
+  border: 1px solid #000000;
+  text-align: left;
+  padding: 8px;
+}
+
+.th1 {
+  background-color: #8D8F8F;
+  border: 1px solid #dddddd;
+  text-align: center;
+  padding: 4px;
+  color: #ffffff
+}
+.th2 {
+  background-color: #dddddd;
+  border: 1px solid #dddddd;
+  text-align: left;
+  padding: 8px;
+}

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -25,6 +25,10 @@ class BulkDiscountsController < ApplicationController
     end
   end
 
+  def edit
+    
+  end
+
   def destroy
     @merchant = Merchant.find(params[:merchant_id])
     @bulk_discount = BulkDiscount.find(params[:id])

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -26,7 +26,8 @@ class BulkDiscountsController < ApplicationController
   end
 
   def edit
-    
+    @merchant = Merchant.find(params[:merchant_id])
+    @discount = BulkDiscount.find(params[:id])
   end
 
   def destroy

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -30,6 +30,10 @@ class BulkDiscountsController < ApplicationController
     @discount = BulkDiscount.find(params[:id])
   end
 
+  def update
+    
+  end
+
   def destroy
     @merchant = Merchant.find(params[:merchant_id])
     @bulk_discount = BulkDiscount.find(params[:id])

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -31,7 +31,11 @@ class BulkDiscountsController < ApplicationController
   end
 
   def update
-    
+    @merchant = Merchant.find(params[:merchant_id])
+    @discount = BulkDiscount.find(params[:id])
+    @discount.update(bulk_discount_params)
+    redirect_to "/merchant/#{@merchant.id}/bulk_discounts/#{@discount.id}"
+    flash[:success] = "Discount Updated Successfully"
   end
 
   def destroy

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,9 @@
+<%= form_with url: "/merchant/#{@merchant.id}/bulk_discounts/#{@discount.id}", method: :patch, local: true do |form| %>
+  <p><%= form.label :percentage_discount, "Percentage Discount: " %></p>
+  <p><%= form.number_field :percentage_discount, value: @discount.percentage_discount, step: 0.01, min: 0.01, max: 1.00  %></p>
+  <br>
+  <p><%= form.label :quantity_threshold, "Quantity Threshold: "  %></p>
+  <p><%= form.number_field :quantity_threshold, value: @discount.quantity_threshold,  min: 1, max: 100000 %></p>
+  <br>
+  <p><%= form.submit 'Update' %></p>
+<% end %>

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,3 +1,5 @@
+<%= link_to "Back", "/merchant/#{@merchant.id}/bulk_discounts/#{@discount.id}" %>
+
 <%= form_with url: "/merchant/#{@merchant.id}/bulk_discounts/#{@discount.id}", method: :patch, local: true do |form| %>
   <p><%= form.label :percentage_discount, "Percentage Discount: " %></p>
   <p><%= form.number_field :percentage_discount, value: @discount.percentage_discount, step: 0.01, min: 0.01, max: 1.00  %></p>

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -6,11 +6,9 @@
   <ul id = 'discount_list'>
     <section id = "discount_indiv" >
       <p><% @merchant.bulk_discounts.each do |discount| %>
-            <h3>
-            <%= link_to "#{(discount.percentage_discount * 100).round}% Discount", "/merchant/#{@merchant.id}/bulk_discounts/#{discount.id}" %>
-            </h3>
+            <h3><%= link_to "#{(discount.percentage_discount * 100).round}% Discount", "/merchant/#{@merchant.id}/bulk_discounts/#{discount.id}" %></h3>
             <p>Quantity Threshold: <%= discount.quantity_threshold %></p>
-            <%= button_to "Delete", "/merchant/#{@merchant.id}/bulk_discounts/#{discount.id}", method: :delete, :onclick=> "return confirm('Are you sure you want to delete this Discount?')" %>
+            <p><%= link_to "Delete", "/merchant/#{@merchant.id}/bulk_discounts/#{discount.id}", method: :delete, :onclick=> "return confirm('Are you sure you want to delete this Discount?')" %></p>
             <br><br>
         <% end %>
       </p> 

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,5 +1,3 @@
-
-
 <%= link_to "Back", "/merchant/#{@merchant.id}/bulk_discounts/" %>
 <h1><%= (@discount.percentage_discount * 100).round %>% Discount</h1>
 <p>Quantity Threshold: <%= @discount.quantity_threshold %></p>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,3 +1,7 @@
+
+
 <%= link_to "Back", "/merchant/#{@merchant.id}/bulk_discounts/" %>
 <h1><%= (@discount.percentage_discount * 100).round %>% Discount</h1>
 <p>Quantity Threshold: <%= @discount.quantity_threshold %></p>
+
+<p><%= link_to "Edit", "/merchant/#{@merchant.id}/bulk_discounts/#{@discount.id}/edit" %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,68 +2,10 @@
 <html>
   <head>
     <title>Little Etsy Shop</title>
+    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
-    <style>
-    .navbar {
-      margin-bottom: 30px;
-    }
-    .navbar-text {
-      margin-top: 1px;
-      margin-bottom: 1px;
-      font-weight: bold;
-    }
-    .col-sm-5 {
-      background-color:lavender;
-      font-weight: bold;
-      text-align:center;
-      margin-right: 80px
-    }
-    .col-sm-4 {
-      text-align:left;
-      margin-right: 80px;
-      margin-left: 10px
-    }
-    .col-sm-6 {
-      background-color:lavenderblush;
-      font-weight: bold;
-      text-align:center;
-    }
-    .col-12 {
-      background-color:#EBEFF3;
-      font-weight: bold;
-      text-align:center;
-      margin-right: 80px;
-      margin-left: 10px
-    }
-
-    .table {
-      font-family: arial, sans-serif;
-      border-collapse: collapse;
-      width: 100%;
-    }
-
-    .td {
-      border: 1px solid #000000;
-      text-align: left;
-      padding: 8px;
-    }
-
-    .th1 {
-      background-color: #8D8F8F;
-      border: 1px solid #dddddd;
-      text-align: center;
-      padding: 4px;
-      color: #ffffff
-    }
-    .th2 {
-      background-color: #dddddd;
-      border: 1px solid #dddddd;
-      text-align: left;
-      padding: 8px;
-    }
-    </style>
   </head>
 
   <body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, except: [:update], controller: "bulk_discounts"
+    resources :bulk_discounts, controller: "bulk_discounts"
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe 'Bulk Discount Show Page', type: :feature do
   before :each do
     @merchant1 = Merchant.create!(name: 'Hair Care')
     @fifteen = @merchant1.bulk_discounts.create!(percentage_discount: 0.15, quantity_threshold: 15)
+    @twenty = @merchant1.bulk_discounts.create!(percentage_discount: 0.20, quantity_threshold: 20)
+
     visit "/merchant/#{@merchant1.id}/bulk_discounts/#{@fifteen.id}/edit"
   end
 
@@ -12,5 +14,9 @@ RSpec.describe 'Bulk Discount Show Page', type: :feature do
     expect(page).to have_field("Percentage Discount", with: "0.15")
     expect(page).to have_field("Quantity Threshold", with: "15")
     expect(page).to have_button("Update")
+
+    expect(page).to_not have_field("Percentage Discount", with: "0.25")
+    expect(page).to_not have_field("Quantity Threshold", with: "20")
+
   end
 end

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe 'Bulk Discount Show Page', type: :feature do
 
     expect(page).to_not have_field("Percentage Discount", with: "0.25")
     expect(page).to_not have_field("Quantity Threshold", with: "20")
+  end
 
+  it 'When I change any/all of the info and click submit, am redirected to discount show page' do
+    fill_in("Percentage Discount", with: "0.30")
+    fill_in("Quantity Threshold", with: "30")
+    click_button("Update")
+    expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts/#{@fifteen.id}")
   end
 end

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'Bulk Discount Show Page', type: :feature do
+
+  before :each do
+    @merchant1 = Merchant.create!(name: 'Hair Care')
+    @fifteen = @merchant1.bulk_discounts.create!(percentage_discount: 0.15, quantity_threshold: 15)
+    visit "/merchant/#{@merchant1.id}/bulk_discounts/#{@fifteen.id}/edit"
+  end
+
+  it 'I see a form to edit the discount, current attributes are prepopulated' do
+    expect(page).to have_field("Percentage Discount", with: "0.15")
+    expect(page).to have_field("Quantity Threshold", with: "15")
+    expect(page).to have_button("Update")
+  end
+end

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe 'Bulk Discount Show Page', type: :feature do
     visit "/merchant/#{@merchant1.id}/bulk_discounts/#{@fifteen.id}/edit"
   end
 
+  it 'has a link to return to the discount show page' do
+    expect(page).to have_link("Back")
+    click_link "Back"
+    expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts/#{@fifteen.id}")
+  end
+
   it 'I see a form to edit the discount, current attributes are prepopulated' do
     expect(page).to have_field("Percentage Discount", with: "0.15")
     expect(page).to have_field("Quantity Threshold", with: "15")

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -60,12 +60,12 @@ RSpec.describe 'Bulk Discounts Index' do
 
   it 'next to each bulk discount, I see a link to delete it' do
     within "#discount_indiv" do
-      expect(page).to have_button("Delete")
+      expect(page).to have_link("Delete")
     end
   end
 
   it 'I click delete link, am redirected to the bulk discounts index page, and no longer see that discount' do
-    first(:button, "Delete").click
+    first(:link, "Delete").click
 
     expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts")
     expect(page).to have_content("Discount Deleted Successfully")

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -32,4 +32,16 @@ RSpec.describe 'Bulk Discount Show Page', type: :feature do
     click_link("Edit")
     expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts/#{@fifteen.id}/edit")
   end
+
+  it 'After submitting edit form, I see that the discount`s attributes have been updated' do
+    visit "/merchant/#{@merchant1.id}/bulk_discounts/#{@fifteen.id}/edit"
+    fill_in("Percentage Discount", with: "0.40")
+    fill_in("Quantity Threshold", with: "50")
+    click_button("Update")
+
+    expect(page).to have_content("40% Discount")
+    expect(page).to have_content("Quantity Threshold: 50")
+    expect(page).to_not have_content("15% Discount")
+    expect(page).to_not have_content("Quantity Threshold: 15")
+  end
 end

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -23,4 +23,13 @@ RSpec.describe 'Bulk Discount Show Page', type: :feature do
     click_link "Back"
     expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts/")
   end
+
+  it 'I see a link to edit the bulk discount' do
+      expect(page).to have_link("Edit")
+  end
+
+  it 'I click edit link and am taken to an edit discount page' do
+    click_link("Edit")
+    expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts/#{@fifteen.id}/edit")
+  end
 end

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Bulk Discount Show Page', type: :feature do
     expect(page).to_not have_content("Quantity Threshold: 30")
   end
 
-  it 'has a link to return to the discount show page' do
+  it 'has a link to return to the discount index page' do
     expect(page).to have_link("Back")
     click_link "Back"
     expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts/")


### PR DESCRIPTION
5: Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated